### PR TITLE
Update Double rule for integer value

### DIFF
--- a/src/rules/double.ts
+++ b/src/rules/double.ts
@@ -11,8 +11,22 @@ const validate = (value: StringOrNumber | StringOrNumber[], params: Record<strin
 
   const regexPart = +decimals === 0 ? '+' : `{${decimals}}`;
   const regex = new RegExp(`^-?\\d+\\${separators[separator as Separator] || '.'}\\d${regexPart}$`);
-
-  return Array.isArray(value) ? value.every(val => regex.test(String(val))) : regex.test(String(value));
+  
+  let valueTemp = value;
+  if (params.separator == "comma") {
+    valueTemp = value.toString().replace(",", ".");
+  }
+  if (!isNaN(value) || !isNaN(valueTemp)) {
+    let valueParsed = parseFloat(valueTemp);
+    if (!Number.isNaN(valueParsed)) {
+      if (!Number.isInteger(valueParsed)) {
+        return Array.isArray(value) ? value.every(val => regex.test(String(val))) : regex.test(String(value));
+      } else {
+        return true;
+      }
+    }
+  }
+  return false;
 };
 
 const params: RuleParamSchema[] = [


### PR DESCRIPTION
Update the double check to accept integer. Let the regex check if value contain alpha or whatever.

🔎 __Overview__
In my app i need to place a value from 0 to infinite. Integer is valid in my API, but the double rule say integer is not a good decimal and every time i update my table, i need to add .0 to each value with integer


 
